### PR TITLE
Added a configuration backend.

### DIFF
--- a/analyzer/apisan/lib/config.py
+++ b/analyzer/apisan/lib/config.py
@@ -1,4 +1,60 @@
-# value for determining majority
-THRESHOLD = 0.8
-MAX_SCORE = 100
-REFERENCE = 3
+from collections import ChainMap
+import pathlib
+import os
+
+_DEFAULTS = dict(
+    # value for determining majority
+    threshold = 0.8,
+    max_score = 100,
+    reference = 3,
+    skip_cache = False,
+    ignored_log_levels = ["debug"],
+)
+
+def parse_json(fp):
+    import json
+    return json.load(fp)
+
+def parse_yaml(fp):
+    import yaml
+    return yaml.load(fp)
+
+_PARSERS = {
+    ".json": parse_json,
+    ".yaml": parse_yaml,
+}
+
+def parse(filename, ext=None):
+    if ext is None:
+        ext = pathlib.Path(filename).suffix
+    try:
+        return _PARSERS[ext](open(filename))
+    except KeyError:
+        raise ValueError("Unsupported extension " + ext)
+
+
+class Options:
+    def __init__(self, data):
+        self.data = data
+    
+    def __getattr__(self, key):
+        return self.data[key]
+    
+    def push(self, data):
+        self.data = ChainMap(data, self.data)
+    
+    def get(self, key, v):
+        return self.data.get(key, v)
+    
+    def __repr__(self):
+        return repr(self.data)
+
+def defaults(env_var="APISAN_CONF", ext=None):
+    try:
+        conf = parse(os.getenv(env_var, "apisan.yaml"))
+        return Options(ChainMap(conf, _DEFAULTS))
+    except IOError:
+        return Options(ChainMap({}, _DEFAULTS))
+
+
+


### PR DESCRIPTION
Create a filename "apisan.yaml" in the current directory to pass configuration options;
these are the same keys/values as in the default configuration options.
The user can override the filename with the environment variable `APISAN_CONF`.
The configuration format can be either written in YAML or in JSON.
This also adds options to ignore caching and control the logging level.
Here's an example of a configuration file that shows debugging messages and ignores cache:
```yaml
# Default values
# threshold: 0.8
# max_score: 100
# reference: 3
# skip_cache: False
# ignored_log_levels: ["debug"]
skip_cache: False
ignored_log_levels: []
```